### PR TITLE
Updating popup timeout to 120 seconds to allow users enough time to type...

### DIFF
--- a/js/src/simple-login/transports/PhoneGap.js
+++ b/js/src/simple-login/transports/PhoneGap.js
@@ -10,7 +10,7 @@ goog.require('fb.simplelogin.util.misc');
  * @const
  * @type {number}
  */
-var popupTimeout = 40000;
+var popupTimeout = 120000;
 
 /**
  * @constructor


### PR DESCRIPTION
Currently the InAppBrowser popup dialog dismisses within 40 seconds, it takes roughly 10 seconds to load) so effectively users have 30 seconds to type their oAuth credentials for Twitter/Facebook/Gmail etc.  This duration is 80% of the time too short and the dialog dismisses while user is typing.
We did a few tests and based on that it feels 120 seconds seems about ok to handle people who type slow.
