### PR TITLE
handle drop in network connectivity

### DIFF
--- a/js/src/simple-login/transports/XHR.js
+++ b/js/src/simple-login/transports/XHR.js
@@ -32,15 +32,19 @@ fb.simplelogin.transports.XHR_.prototype.open = function(url, data, onComplete) 
 
   var callbackHandler = function() {
     if (!callbackInvoked && xhr.readyState === 4) {
-      callbackInvoked = true;
-
       var data, error;
-      try {
-        data = fb.simplelogin.util.json.parse(xhr.responseText);
-        error = data['error'] || null;
-        delete data['error'];
-      } catch(e) {}
-
+      callbackInvoked = true;
+      if ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 304 || xhr.status == 1223) {
+        try {
+          data = fb.simplelogin.util.json.parse(xhr.responseText);
+          error = data["error"] || null;
+          delete data["error"];
+        } catch (e) {
+          error = "UNKNOWN_ERROR"
+        }
+      } else {
+        error = "RESPONSE_PAYLOAD_ERROR";
+      }
       return onComplete && onComplete(error, data);
     }
   };


### PR DESCRIPTION
A drop in network connection during the create user or login process leads to the following crash (Chrome 36.0.1985.125):

![image](https://cloud.githubusercontent.com/assets/429802/3890258/4448de98-221c-11e4-83e0-76481441f8d3.png)

This occurs when an error is thrown and not caught when we try to parse the empty response text that is returned by XMLHttpRequest when the status is not 200 (0 in the case where network connection is removed).

To replicate, break at 1756 of firebase-simple-login-debug.js, and remove the network cable before resuming beyond the break point. xhr.readyState becomes 4 but xhr.responseText = "", causing the JSON parser to throw an error and undefined error and data to be passed to the onCompleteHandler.

![image](https://cloud.githubusercontent.com/assets/429802/3890264/4f652f02-221c-11e4-9f78-53476c254ae9.png)

The PR hopes to resolve this by setting an error value if the xhr.status != 200 or if a general JSON parse error occurs.
